### PR TITLE
feat: key not from file & other improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ erased-serde = "0.4.1"
 reqwest = { version = "0.11.0", features = ["json"], default-features = false }
 chrono = "0.4"
 log = "0.4"
-gauth = { git = "https://github.com/WalletConnect/gauth-rs.git", branch = "feat/key-not-from-file" }
+gauth = { git = "https://github.com/WalletConnect/gauth-rs.git", branch = "feat/key-not-from-file" } # TODO switch to tagged version once released
 dotenv = { version = "0.15.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Suvish Varghese Thoovamalayil <vishy1618@gmail.com>",
   "panicbit <panicbit.dev@gmail.com>",
   "Julius de Bruijn <pimeys@gmail.com>",
-  "Richard Jansen <demo_epso@proton.me>"
+  "Richard Jansen <demo_epso@proton.me>",
 ]
 description = "An API to talk to FCM (Firebase Cloud Messaging) in Rust"
 license = "MIT"
@@ -16,20 +16,21 @@ keywords = ["fcm", "firebase", "notification"]
 edition = "2018"
 
 [features]
-default = ["native-tls"]
+default = ["native-tls", "dotenv"]
 native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
 vendored-tls = ["reqwest/native-tls-vendored"]
+dotenv = ["dep:dotenv"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 erased-serde = "0.4.1"
-reqwest = {version = "0.11.0", features = ["json"], default-features=false}
+reqwest = { version = "0.11.0", features = ["json"], default-features = false }
 chrono = "0.4"
 log = "0.4"
-gauth = "0.7.0"
-dotenv = "0.15.0"
+gauth = { git = "https://github.com/WalletConnect/gauth-rs.git", branch = "feat/key-not-from-file" }
+dotenv = { version = "0.15.0", optional = true }
 
 [dev-dependencies]
 argparse = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dotenv = ["dep:dotenv"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 erased-serde = "0.4.1"
-reqwest = { version = "0.11.0", features = ["json"], default-features = false }
+reqwest = { version = "0.12.4", features = ["json"], default-features = false }
 chrono = "0.4"
 log = "0.4"
 gauth = { git = "https://github.com/WalletConnect/gauth-rs.git", branch = "feat/key-not-from-file" } # TODO switch to tagged version once released

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fcm"
-version = "1.0.0"
+version = "0.10.0"
 authors = [
   "Suvish Varghese Thoovamalayil <vishy1618@gmail.com>",
   "panicbit <panicbit.dev@gmail.com>",
@@ -31,8 +31,12 @@ chrono = "0.4"
 log = "0.4"
 gauth = { git = "https://github.com/WalletConnect/gauth-rs.git", branch = "feat/key-not-from-file" } # TODO switch to tagged version once released
 dotenv = { version = "0.15.0", optional = true }
+thiserror = "1"
 
 [dev-dependencies]
 argparse = "0.2.1"
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 pretty_env_logger = "0.5.0"
+
+# [patch.'https://github.com/WalletConnect/gauth-rs.git']
+# gauth = { path = "../gauth-rs" }

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         ap.parse_args_or_exit();
     }
 
-    let client = Client::new().unwrap();
+    let client = Client::new().await.unwrap();
 
     let data = json!({
         "key": "value",

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         ap.parse_args_or_exit();
     }
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
 
     let data = json!({
         "key": "value",
@@ -29,8 +29,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let builder = Message {
         data: Some(data),
         notification: Some(Notification {
-            title: Some("I'm high".to_string()),
-            body: Some(format!("it's {}", chrono::Utc::now())),
+            title: Some("Test FCM notification".to_string()),
+            body: Some(format!("It's {}", chrono::Utc::now())),
             ..Default::default()
         }),
         target: Target::Token(device_token),
@@ -40,8 +40,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         android: Some(AndroidConfig {
             priority: Some(fcm::AndroidMessagePriority::High),
             notification: Some(AndroidNotification {
-                title: Some("I'm Android high".to_string()),
-                body: Some(format!("Hi Android, it's {}", chrono::Utc::now())),
+                title: Some("Android: Test FCM notification".to_string()),
+                body: Some(format!("Android: It's {}", chrono::Utc::now())),
                 ..Default::default()
             }),
             ..Default::default()

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -105,6 +105,7 @@ impl Client {
                 }
                 Err(SendError::UnknownError404Response(response))
             }
+            StatusCode::FORBIDDEN => Err(SendError::Forbidden),
             // StatusCode::UNAUTHORIZED => Err(Error::Unauthorized),
             // StatusCode::BAD_REQUEST => {
             //     let body = response.text().await.unwrap();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -9,7 +9,7 @@ use reqwest::{Client as HttpClient, StatusCode};
 use serde::Serialize;
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 /// An async client for sending the notification payload.
 pub struct Client {
     http_client: HttpClient,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -105,7 +105,10 @@ impl Client {
             // }
             // status if status.is_server_error() => Err(Error::ServerError(retry_after)),
             // _ => Err(Error::InvalidMessage("Unknown Error".to_string())),
-            _ => Err(SendError::HttpRequest(response.error_for_status().unwrap_err())), // TODO
+            _ => Err(SendError::UnknownHttpResponse {
+                status: response_status,
+                body: response.text().await,
+            }),
         }
     }
 }

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -120,6 +120,13 @@ pub enum SendError {
 
     #[error("Error sending message: {0}")]
     HttpRequest(reqwest::Error),
+
+    #[error("Unknown response")]
+    UnknownHttpResponse {
+        status: reqwest::StatusCode,
+        body: reqwest::Result<String>,
+    }
+
     // TODO retry after error
 
     // TODO error variant for invalid authentication

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -151,6 +151,10 @@ pub enum SendError {
 
     #[error("Client unregistered")]
     Unregistered,
+
+    #[error("Not allowed to call this API")]
+    Forbidden,
+
     // TODO retry after error
 
     // TODO error variant for invalid authentication

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -236,7 +236,7 @@ mod tests {
             });
 
             let response_string = serde_json::to_string(&response_data).unwrap();
-            let fcm_response: Response = serde_json::from_str(&response_string).unwrap();
+            let fcm_response = serde_json::from_str::<Response>(&response_string).unwrap();
 
             assert_eq!(Some(error_enum), fcm_response.results.unwrap()[0].error);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!     use serde_json::json;
 //!     use fcm::{Target, FcmOptions, Notification, Message};
-//!     let client = fcm::Client::new();
+//!     let client = fcm::Client::new()?;
 //!
 //!     let data = json!({
 //!         "message": "Howdy!"
@@ -70,5 +70,5 @@ pub use crate::web::webpush_config::*;
 pub use crate::web::webpush_fcm_options::*;
 
 mod client;
-pub use crate::client::response::FcmError as Error;
+pub use crate::client::response::*;
 pub use crate::client::*;

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -47,7 +47,7 @@ fn should_add_custom_data_to_the_payload() {
     let data = json!({ "foo": "bar", "bar": false });
 
     let builder = Message {
-        target: target,
+        target,
         data: Some(data),
         notification: None,
         android: None,
@@ -179,5 +179,5 @@ fn should_set_notifications() {
     };
     let msg = builder.finalize();
 
-    assert_eq!(msg.notification.is_none(), false);
+    assert!(msg.notification.is_some());
 }


### PR DESCRIPTION
This adds support for reading the service account key from a `ServiceAccountKey` rather than the default using the `dotenv` variable. Also:
- Adds a default feature flag for the `dotenv` dependency and functionality for `Client::new()`. `new()` now returns a `Result` since loading the key is performed immediately rather than later. Remove `Default` implementation since it doesn't support errors
- Add `ClientBuilder` pattern which enables more complex constructors such as allowing to provide a custom reqwest HTTP client
- Rename and re-export types in `client::response` to enable callers to match on the error variants. Re-export `gauth` to enable access to `ServiceAccountKey`
- Share the HTTP client with gauth
- Pull `project_id` from `ServiceAccountKey` rather than double-parsing the value
- Remove `.pool_max_idle_per_host(usize::MAX)` configuration on reqwest since this is the default
- Take advantage of gauth now returning bearer token directly for simplified code
- Switch to `.json()` helper from reqwest to construct JSON request bodies over doing this by hand with `.body()`, `Content-Type` header, and serde
- Resolves various clippy and fmt errors

Resolves #5 

Depends on https://github.com/makarski/gauth-rs/pull/29

Example usage in the project I'm working on: https://github.com/WalletConnect/push-server/pull/316