### PR TITLE
Dry run

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -82,8 +82,13 @@ impl AsRef<Message> for Message {
 }
 
 /// Wrap the message in a "message" field
+fn is_validate_only_default(b: &bool) -> bool {
+    *b == false
+}
+
 #[derive(Serialize)]
 pub(crate) struct MessageWrapper<'a> {
+    #[serde(skip_serializing_if = "is_validate_only_default")]
     validate_only: bool,
     message: &'a Message,
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -84,11 +84,15 @@ impl AsRef<Message> for Message {
 /// Wrap the message in a "message" field
 #[derive(Serialize)]
 pub(crate) struct MessageWrapper<'a> {
+    validate_only: bool,
     message: &'a Message,
 }
 
 impl MessageWrapper<'_> {
-    pub fn new(message: &Message) -> MessageWrapper {
-        MessageWrapper { message }
+    pub fn new(message: &Message, dry_run: bool) -> MessageWrapper {
+        MessageWrapper { 
+            validate_only: dry_run,
+            message
+        }
     }
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -95,9 +95,9 @@ pub(crate) struct MessageWrapper<'a> {
 
 impl MessageWrapper<'_> {
     pub fn new(message: &Message, dry_run: bool) -> MessageWrapper {
-        MessageWrapper { 
+        MessageWrapper {
             validate_only: dry_run,
-            message
+            message,
         }
     }
 }


### PR DESCRIPTION
The FCM v1 API supports a `validate_only` flag: https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/send . This is also known as a dry run in the Firebase Admin SDK. Messages that are sent with this flag enabled can effectively be used to test aspects such as network performance, while skipping the actual delivery of these messages to any devices.

This pull request adds the required field to the `MessageWrapper`, and introduces a new `dry_run(...)` function to the `FcmClientBuilder` to enable it. The default behaviour remains unchanged and will send messages through to devices. To use the dry run functionality you add `dry_run(true)`:
```
let client = fcm::FcmClient::builder()
    ...
    .dry_run(true)
    .build()
```
The serialization is set up to skip the new field when it is set to `false` to ensure behaviour identical to the original implementation when `dry_run(false)` or when it is omitted.