### PR TITLE
allow dry-run status to be determined on an FcmClient

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -101,7 +101,7 @@ impl FcmClientBuilder {
 pub struct FcmClient {
     http_client: reqwest::Client,
     oauth_client: OauthClient,
-    dry_run: bool,
+    pub dry_run: bool,
 }
 
 impl FcmClient {


### PR DESCRIPTION
A tiny little improvement on my previous pull request. Since you're likely to use `dry_run(true)` for debugging it also makes sense that you are able to deduce whether it is in that state, e.g. for logging purposes. Making the `dry_run` field public gives you that ability.